### PR TITLE
Refactor: single reusable header component.

### DIFF
--- a/components/QuestSearch/index.tsx
+++ b/components/QuestSearch/index.tsx
@@ -5,14 +5,18 @@ import { questsSearchClient } from "typesense/insantsearch"
 import { InstantSearch } from "react-instantsearch-dom"
 import { RefinementList, Pagination, SearchBox } from "../SearchComponents"
 import { Button, Stack, Divider, Container } from "@mui/material"
-import { FindQuestBanner } from "./FindQuestBanner"
+import { PageHeader } from "../ReusableComponents/PageHeader"
 
 export function Quests(): JSX.Element {
   const firestore = useFirestore()
 
   return (
     <Stack>
-      <FindQuestBanner />
+      <PageHeader
+        greenSubtitle="Your journey awaits you"
+        header="Find a new quest"
+        greySubtitle="All of the quests currently available for completion in Guilds"
+      />
       <Container>
         <InstantSearch searchClient={questsSearchClient} indexName="quests">
           <Stack

--- a/components/ReusableComponents/PageHeader.tsx
+++ b/components/ReusableComponents/PageHeader.tsx
@@ -1,7 +1,7 @@
 import { Stack, Typography } from "@mui/material"
 import { Container } from "@mui/system"
 
-export function FindQuestBanner() {
+export function PageHeader({ greenSubtitle, header, greySubtitle }) {
   return (
     <Stack
       sx={{
@@ -20,13 +20,13 @@ export function FindQuestBanner() {
             variant="body1"
             sx={{ fontWeight: 600, color: "primary.main" }}
           >
-            Your journey awaits you
+            {greenSubtitle}
           </Typography>
           <Typography variant="h2" sx={{ fontWeight: 600 }}>
-            Find a new quest
+            {header}
           </Typography>
           <Typography variant="body1" sx={{ color: "text.secondary" }}>
-            All of the quests currently available for completion in Guilds
+            {greySubtitle}
           </Typography>
         </Stack>
       </Container>


### PR DESCRIPTION
Resolves #114 - refactor QuestSearch header into a reusable header component that can be used across other pages. Before, there was a one-off QuestSearch Header, now we can use this:

![Screenshot 2022-11-08 at 19 30 44](https://user-images.githubusercontent.com/49661708/200658378-e7e1199b-8cca-4873-87b1-a66436b5b71b.png)