### PR TITLE
Feature: mentor card

### DIFF
--- a/components/SearchMentors/MentorCard.tsx
+++ b/components/SearchMentors/MentorCard.tsx
@@ -1,0 +1,68 @@
+import { Box, Stack, Typography, Button } from "@mui/material"
+import LinesElipsis from "react-lines-ellipsis"
+import styled from "styled-components"
+import { StorageImage } from "reactfire"
+import { Hero } from "storage/hero"
+
+interface MentorProps {
+  mentor: Hero
+}
+
+export function MentorCard({ mentor }: MentorProps) {
+  const MentorPicture = styled(StorageImage)({
+    objectFit: "cover",
+    height: 290,
+  })
+
+  return (
+    <Box sx={{ maxWidth: 280 }}>
+      <Stack spacing={3}>
+        <MentorPicture storagePath={`${mentor?.profilePicture}`} />
+        <Stack spacing={0.5}>
+          <Typography variant="h6" fontWeight={500} color="text.primary">
+            {mentor?.mentor.skill}
+          </Typography>
+          <Typography
+            variant="body1"
+            fontWeight={200}
+            color="text.secondary"
+          >{`${mentor?.name.first} ${mentor?.name.last}`}</Typography>
+          <Typography
+            variant="body1"
+            fontWeight={400}
+            color="primary.main"
+          >{`Between £${mentor?.mentor.minRate} - £${mentor?.mentor.maxRate} p/h`}</Typography>
+        </Stack>
+        <Typography variant="body2" color="text.secondary">
+          <LinesElipsis
+            text={mentor?.mentor.bio}
+            maxLine="3"
+            ellipsis="..."
+            trimRight
+            basedOn="words"
+          />
+        </Typography>
+        <Box sx={{ justifyContent: "flex-start" }}>
+          <Button
+            variant="outlined"
+            size="medium"
+            sx={{
+              height: "3rem",
+              borderColor: (theme) => theme.palette.grey[300],
+            }}
+          >
+            <Typography
+              variant="body1"
+              textTransform="none"
+              px="0.6rem"
+              fontWeight={500}
+              color={(theme) => theme.palette.grey[700]}
+            >
+              Message {mentor?.name.first}
+            </Typography>
+          </Button>
+        </Box>
+      </Stack>
+    </Box>
+  )
+}

--- a/components/SearchMentors/MentorCard.tsx
+++ b/components/SearchMentors/MentorCard.tsx
@@ -15,27 +15,27 @@ export function MentorCard({ mentor }: MentorProps) {
   })
 
   return (
-    <Box sx={{ maxWidth: 280 }}>
+    <Box sx={{ maxWidth: 280, p: 1 }}>
       <Stack spacing={3}>
-        <MentorPicture storagePath={`${mentor?.profilePicture}`} />
+        <MentorPicture storagePath={`${mentor.profilePicture}`} />
         <Stack spacing={0.5}>
           <Typography variant="h6" fontWeight={500} color="text.primary">
-            {mentor?.mentor.skill}
+            {mentor.mentor.skill}
           </Typography>
           <Typography
             variant="body1"
             fontWeight={200}
             color="text.secondary"
-          >{`${mentor?.name.first} ${mentor?.name.last}`}</Typography>
+          >{`${mentor.name.first} ${mentor.name.last}`}</Typography>
           <Typography
             variant="body1"
             fontWeight={400}
             color="primary.main"
-          >{`Between £${mentor?.mentor.minRate} - £${mentor?.mentor.maxRate} p/h`}</Typography>
+          >{`Between £${mentor.mentor.minRate} - £${mentor.mentor.maxRate} p/h`}</Typography>
         </Stack>
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" color="text.secondary" align="justify">
           <LinesElipsis
-            text={mentor?.mentor.bio}
+            text={mentor.mentor.bio}
             maxLine="3"
             ellipsis="..."
             trimRight
@@ -48,17 +48,14 @@ export function MentorCard({ mentor }: MentorProps) {
             size="medium"
             sx={{
               height: "3rem",
-              borderColor: (theme) => theme.palette.grey[300],
             }}
           >
             <Typography
               variant="body1"
               textTransform="none"
-              px="0.6rem"
               fontWeight={500}
-              color={(theme) => theme.palette.grey[700]}
             >
-              Message {mentor?.name.first}
+              Message {mentor.name.first}
             </Typography>
           </Button>
         </Box>

--- a/components/SearchMentors/MentorCard.tsx
+++ b/components/SearchMentors/MentorCard.tsx
@@ -50,11 +50,7 @@ export function MentorCard({ mentor }: MentorProps) {
               height: "3rem",
             }}
           >
-            <Typography
-              variant="body1"
-              textTransform="none"
-              fontWeight={500}
-            >
+            <Typography variant="body1" textTransform="none" fontWeight={500}>
               Message {mentor.name.first}
             </Typography>
           </Button>

--- a/components/SearchMentors/index.tsx
+++ b/components/SearchMentors/index.tsx
@@ -20,7 +20,6 @@ export function SearchMentors() {
         <Stack spacing={6}>
           <Stack direction="row">
             {/*TO DO: ADD REUSABLE SLIDER COMPONENT */}
-
             {mentorsStatus === "success" ? (
               mentors &&
               mentors?.map((mentor: Hero, idx) => (

--- a/components/SearchMentors/index.tsx
+++ b/components/SearchMentors/index.tsx
@@ -1,0 +1,37 @@
+import { useFirestore, useFirestoreCollectionData } from "reactfire"
+import { collection, query, where } from "firebase/firestore"
+import { Stack, Typography } from "@mui/material"
+import "firebase/firestore"
+import { Container } from "@mui/system"
+import { Hero } from "storage/hero"
+import { MentorCard } from "./MentorCard"
+
+export function SearchMentors() {
+  const firestore = useFirestore()
+  const heroesCollection = collection(firestore, `heroes`)
+  const mentorsQuery = query(heroesCollection, where("isMentor", "==", true))
+
+  const { status: mentorsStatus, data: mentors } =
+    useFirestoreCollectionData(mentorsQuery)
+
+  return (
+    <Stack spacing={4} alignItems="center" sx={{ overflow: "clip" }}>
+      <Container>
+        <Stack spacing={6}>
+          <Stack direction="row">
+            {/*TO DO: ADD REUSABLE SLIDER COMPONENT */}
+
+            {mentorsStatus === "success" ? (
+              mentors &&
+              mentors?.map((mentor: Hero, idx) => (
+                <MentorCard key={idx} mentor={mentor} />
+              ))
+            ) : (
+              <Typography>Loading...</Typography>
+            )}
+          </Stack>
+        </Stack>
+      </Container>
+    </Stack>
+  )
+}

--- a/storage/hero/types.ts
+++ b/storage/hero/types.ts
@@ -17,6 +17,15 @@ export interface Hero {
   portfolio?: URL[]
   experience?: Experience[]
   rating?: number
+  isMentor?: boolean
+  mentor?: Mentor
+}
+
+export type Mentor = {
+  bio: string
+  skill: string
+  maxRate: string
+  minRate: string
 }
 
 export type Location = {


### PR DESCRIPTION
Resolves #103 (and part of 113) 

Add **reusable mentor card component**. Also add the **parent component to search for mentors**, including retrieval of mentors from Firebase. **Components displayed static side-by-side for now, but will be displayed in carousel as part of future pull request** (@JakubFrackowiak has built a universal carousel/slider component that has not yet been merged).

![Screenshot 2022-11-11 at 09 00 36](https://user-images.githubusercontent.com/49661708/201308740-99d575d3-fb9b-448b-a946-43b8caedc0cf.png)

**Important**: There was a decision about whether to have separate 'mentors' collection, or to include 'mentor' data as part of hero data. After discussing with Oli I have gone with the second option which is more efficient, because we don't have to make two separate requests for each mentor (considering shared name, level, bio, profile picture etc). 

So I have updated the 'hero' type to include mentor data like below. There will likely be more properties to add to this, but this is what is needed for now. The 'isMentor' boolean allows us to filter for active mentors, without user having to delete the mentor object each time which is the best way to do this I think.

![Screenshot 2022-11-11 at 09 11 46](https://user-images.githubusercontent.com/49661708/201308792-134bbabf-b2af-4f37-93c6-9ab3f88dce64.png)

On Firebase:

![Screenshot 2022-11-10 at 20 03 43](https://user-images.githubusercontent.com/49661708/201309108-81d4b9f7-9259-4858-8854-651dd4f56921.png)


