### PR TITLE
Feature: add team/quest page banner

### DIFF
--- a/components/IndividualQuestBanner.tsx
+++ b/components/IndividualQuestBanner.tsx
@@ -62,7 +62,7 @@ export function IndividualQuestBanner({
                 borderRadius: "16px",
               }}
             >
-              @yoniaibi holds the top bid
+              {topBid.userName} holds the top bid
             </Typography>
             <Typography
               display="inline"
@@ -139,10 +139,7 @@ export function IndividualQuestBanner({
           </CaseStudyLink>
         </Stack>
       </Stack>
-      <QuestImage
-        storagePath={`quests/${"1200px-Calico_tabby_cat_-_Savannah.jpeg"}`}
-        alt=""
-      />
+      <QuestImage storagePath={`quests/${quest?.image}`} alt="" />
     </Stack>
   )
 }

--- a/components/IndividualQuestBanner.tsx
+++ b/components/IndividualQuestBanner.tsx
@@ -1,0 +1,148 @@
+import { Button, Stack, Box, Typography, Avatar } from "@mui/material"
+import { Hero } from "types/hero"
+import { Quest } from "types/quest"
+import Link from "next/link"
+import styled from "@emotion/styled"
+import {
+  StorageImage,
+  useFirestoreCollectionData,
+  useFirestore,
+} from "reactfire"
+import { collection, limit, orderBy, query } from "firebase/firestore"
+
+interface IndividualQuestBannerProps {
+  hero: Hero
+  quest: Quest
+}
+
+const QuestImage = styled(StorageImage)({
+  objectFit: "cover",
+  maxWidth: 460,
+  maxHeight: 540,
+  p: 20,
+  aspectRatio: "7/8",
+})
+
+const CaseStudyLink = styled(Link)`
+  text-decoration: none;
+`
+
+export function IndividualQuestBanner({
+  hero,
+  quest,
+}: IndividualQuestBannerProps) {
+  const firestore = useFirestore()
+  const bidsRef = collection(firestore, `quests/${quest?.id}/bids`)
+  const topBidsQuery = query(bidsRef, orderBy("amount", "asc"), limit(1))
+  const { data: topBids } = useFirestoreCollectionData(topBidsQuery)
+  const topBid = topBids?.[0]
+
+  return (
+    <Stack spacing={3} direction={{ lg: "row", xl: "row" }} alignItems="start">
+      <Stack width={576} mb={{ xs: "2rem", sm: "2rem", md: "2rem" }}>
+        <Stack spacing={2} mb="2rem">
+          <Box
+            display="flex"
+            sx={{
+              padding: "4px 10px 4px 4px",
+              width: "max-content",
+              backgroundColor: "#FFFAEB",
+              borderRadius: "16px",
+            }}
+          >
+            <Typography
+              display="inline"
+              sx={{
+                py: 0.5,
+                px: 1,
+                fontWeight: "500",
+                fontSize: "0.75rem",
+                backgroundColor: "#FFFFFF",
+                color: "#B54708",
+                borderRadius: "16px",
+              }}
+            >
+              @yoniaibi holds the top bid
+            </Typography>
+            <Typography
+              display="inline"
+              color="#B54708"
+              sx={{ p: 0.5, ml: 1, fontSize: "0.75rem", fontWeight: "500" }}
+            >
+              {topBid?.amount}
+            </Typography>
+          </Box>
+          <Typography variant="h3" fontSize={"3.75rem"}>
+            {quest?.title}
+          </Typography>
+        </Stack>
+        <Typography
+          sx={{
+            color: "#667085",
+            fontWeight: 400,
+            fontSize: "1.25rem",
+            lineHeight: "1.875rem",
+          }}
+        >
+          {quest?.description}
+        </Typography>
+        <Stack
+          display="flex"
+          flexDirection="row"
+          alignItems="center"
+          sx={{ my: 3 }}
+        >
+          <Avatar
+            src={hero?.profilePicture}
+            sx={{ width: 56, height: 56, m: 1, mb: 2 }}
+          />
+          <Stack>
+            <Typography>
+              {hero?.name.first} {hero?.name.last}
+            </Typography>
+            <Typography
+              sx={{
+                fontWeight: 400,
+                size: "1rem",
+                lineHeight: "1.5rem",
+                color: "#667085",
+              }}
+            >
+              Created 14th July 2022
+            </Typography>
+          </Stack>
+        </Stack>
+        <Stack direction="row" spacing={2}>
+          <CaseStudyLink href="#">
+            <Button
+              variant="outlined"
+              sx={{
+                borderRadius: "0.5rem",
+                height: "3rem",
+                color: "text.primary",
+                borderColor: (theme) => theme.palette.grey[300],
+              }}
+            >
+              <Typography textTransform="none">More information</Typography>
+            </Button>
+          </CaseStudyLink>
+          <CaseStudyLink href="#">
+            <Button
+              variant="contained"
+              sx={{
+                height: "3rem",
+                borderRadius: "0.5rem",
+              }}
+            >
+              <Typography textTransform="none">Place a bid</Typography>
+            </Button>
+          </CaseStudyLink>
+        </Stack>
+      </Stack>
+      <QuestImage
+        storagePath={`quests/${"1200px-Calico_tabby_cat_-_Savannah.jpeg"}`}
+        alt=""
+      />
+    </Stack>
+  )
+}

--- a/components/IndividualQuestBanner.tsx
+++ b/components/IndividualQuestBanner.tsx
@@ -139,7 +139,7 @@ export function IndividualQuestBanner({
           </CaseStudyLink>
         </Stack>
       </Stack>
-      <QuestImage storagePath={`quests/${quest?.image}`} alt="" />
+      <QuestImage storagePath={`quests/${quest?.image}`} alt={`${quest?.title} quest image`} />
     </Stack>
   )
 }

--- a/components/IndividualQuestBanner.tsx
+++ b/components/IndividualQuestBanner.tsx
@@ -139,7 +139,10 @@ export function IndividualQuestBanner({
           </CaseStudyLink>
         </Stack>
       </Stack>
-      <QuestImage storagePath={`quests/${quest?.image}`} alt={`${quest?.title} quest image`} />
+      <QuestImage
+        storagePath={`quests/${quest?.image}`}
+        alt={`${quest?.title} quest image`}
+      />
     </Stack>
   )
 }


### PR DESCRIPTION
Adding the banner that is used on the individual quest and team pages:

![Screenshot 2023-01-17 at 19 52 15](https://user-images.githubusercontent.com/49661708/213021069-7036a2a7-4b94-42f1-a284-6f2ee5581fd6.png)

A couple of fields are necessarily hard-coded at this stage, but I can fix that in due course. 